### PR TITLE
Add buf-size#boundedBlockLength as a provided feature.

### DIFF
--- a/src/lv2ttl.cc
+++ b/src/lv2ttl.cc
@@ -342,6 +342,7 @@ int LV2Parser::parse (const char* plugin_uri)
 			if (!strcmp (rf, "http://lv2plug.in/ns/ext/urid#unmap")) { ok = true; }
 			if (!strcmp (rf, "http://lv2plug.in/ns/ext/worker#schedule")) { ok = true; }
 			if (!strcmp (rf, "http://lv2plug.in/ns/ext/options#options")) { ok = true; }
+			if (!strcmp (rf, "http://lv2plug.in/ns/ext/buf-size#boundedBlockLength")) { ok = true; }
 			if (!ok) {
 				fprintf (stderr, "Unsupported required feature: '%s' in '%s'\n", rf, plugin_uri);
 				err = 1;

--- a/src/lv2vst.cc
+++ b/src/lv2vst.cc
@@ -150,11 +150,13 @@ void LV2Vst::init ()
 	const LV2_Feature map_feature      = { LV2_URID__map, &uri_map};
 	const LV2_Feature unmap_feature    = { LV2_URID__unmap, &uri_unmap };
 	const LV2_Feature options_feature  = { LV2_OPTIONS__options, (void*)&options };
+	const LV2_Feature bounded_block_length_feature  = { LV2_BUF_SIZE__boundedBlockLength , NULL };
 
 	const LV2_Feature* features[] = {
 		&map_feature,
 		&unmap_feature,
 		&schedule_feature,
+		&bounded_block_length_feature,
 		&options_feature,
 		NULL
 	};


### PR DESCRIPTION
This is to not block plugins that "require" `buf-size#boundedBlockLength`
as a feature.

It is already part of "options", but those options are never exposed as
provided features when it is instantiating a plugin, nor permitted as
a feature that a plugin can require.

sfizz and some Carla plugins are known to be refused as a result. This
change saves those plugins (not meaning that they then work; sfizz still
needs some way to pass filename, which is not clear to me).